### PR TITLE
Enhance theme switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,9 @@
 	<div class="cntr">
 		<div class="row press">
 			<input type="checkbox" id="unchecked" class="cbx hidden" value="Enable Light Mode" onclick="toggle()"
-			       autocomplete="off" checked>
+						 autocomplete="off" checked>
 			<label for="unchecked" class="lbl"></label>
+			<div id="darkthemecurtain"></div>
 		</div>
 	</div>
 </header>

--- a/scripts/darkMode.js
+++ b/scripts/darkMode.js
@@ -1,44 +1,100 @@
 let systemThemeToggle = false;
 function toggle() {
-    
     let themeButton = document.getElementById("unchecked");
+    const buttonLabel = document.querySelector("#unchecked ~ label");
+    const curtain = document.getElementById("darkthemecurtain");
     let svg5 = document.getElementsByClassName('st5');
     let svg3 = document.getElementsByClassName('st3');
     let svg4 = document.getElementsByClassName('st4');
-    if (themeButton.value === "Enable Light Mode"){
-        if(!systemThemeToggle){
-            localStorage.setItem("mode", "light");
+    const toggleSize = buttonLabel.getBoundingClientRect();
+    curtain.style.left = toggleSize.left + "px";
+    buttonLabel.style.zIndex = "999";
+    curtain.style.display = "block";
+    requestAnimationFrame(() => {
+        if (themeButton.value === "Enable Light Mode"){
+            if(!systemThemeToggle){
+                localStorage.setItem("mode", "light");
+            }
+            curtain.style.transform = "translate(-2px, -3px)";
+            curtain.addEventListener('transitionend', () => {
+                themeButton.value = "Enable Dark Mode";
+                document.body.style.backgroundColor = "#f5f5f5";
+                document.getElementById("header").style.backgroundColor = "#f5f5f5";
+                document.getElementById("spn").style.color = "rgba(33,33,33,0.8)";
+                for (let i = 0; i < svg5.length; i++) {
+                    svg5[i].style.fill = "rgba(0, 0, 0, 0.1)";
+                }
+                for (let i = 0; i < svg3.length; i++) {
+                    svg3[i].style.fill = "#f5f5f5";
+                }
+                for (let i = 0; i < svg4.length; i++) {
+                    svg4[i].style.fill = "#757575";
+                }
+                requestAnimationFrame(() => {
+                    curtain.addEventListener('transitionend', () => {
+                        buttonLabel.style.zIndex = "";
+                        curtain.style.left = "";
+                        curtain.style.opacity = "";
+                        curtain.style.display = "";
+                        curtain.style.transform = "";
+                        curtain.style.background = "";
+                    }, { once: true });
+                    curtain.style.opacity = "0";
+                });
+            }, { once: true });
+            requestAnimationFrame(() => {
+                const diameter = Math.sqrt(
+                    Math.pow(window.innerWidth - toggleSize.left, 2) +
+                    Math.pow(window.innerHeight - toggleSize.top, 2)
+                );
+                const scale = diameter / 13;
+                curtain.style.transform = "scale(" + scale + ") translate(" + -19 / scale + "px, " + -3 / scale + "px)";
+                curtain.style.opacity = "1";
+            });
         }
-        themeButton.value = "Enable Dark Mode";
-        document.body.style.backgroundColor = "#f5f5f5";
-        document.getElementById("header").style.backgroundColor = "#f5f5f5";
-        document.getElementById("spn").style.color = "rgba(33,33,33,0.8)";
-        for (let i = 0; i < svg5.length; i++) {
-            svg5[i].style.fill = "rgba(0, 0, 0, 0.1)";
+        else {
+            if(!systemThemeToggle){
+                localStorage.setItem("mode", "light");
+            }
+            curtain.style.transform = "translate(19px, -3px)";
+            curtain.style.background = "rgb(32, 33, 36)";
+            curtain.addEventListener('transitionend', () => {
+                themeButton.value = "Enable Light Mode";
+                document.body.style.backgroundColor = "#202124";
+                document.getElementById("header").style.backgroundColor = "#202124";
+                document.getElementById("spn").style.color = "whitesmoke";
+                for (let i = 0; i < svg5.length; i++) {
+                    svg5[i].style.fill = "rgba(255, 255, 255, 0.1)";
+                }
+                for (let i = 0; i < svg3.length; i++) {
+                    svg3[i].style.fill = "#212121";
+                }
+                for (let i = 0; i < svg4.length; i++) {
+                    svg4[i].style.fill = "#dfe0e4";
+                }
+                requestAnimationFrame(() => {
+                    curtain.addEventListener('transitionend', () => {
+                        buttonLabel.style.zIndex = "";
+                        curtain.style.left = "";
+                        curtain.style.opacity = "";
+                        curtain.style.display = "";
+                        curtain.style.transform = "";
+                        curtain.style.background = "";
+                    }, { once: true });
+                    curtain.style.opacity = "0";
+                });
+            }, { once: true });
+            requestAnimationFrame(() => {
+                const diameter = Math.sqrt(
+                    Math.pow(window.innerWidth - toggleSize.left, 2) +
+                    Math.pow(window.innerHeight - toggleSize.top, 2)
+                );
+                const scale = diameter / 13;
+                curtain.style.transform = "scale(" + scale + ") translate(" + -2 / scale + "px, " + -3 / scale + "px)";
+                curtain.style.opacity = "1";
+            });
         }
-        for (let i = 0; i < svg3.length; i++) {
-            svg3[i].style.fill = "#f5f5f5";
-        }
-        for (let i = 0; i < svg4.length; i++) {
-            svg4[i].style.fill = "#757575";
-        }
-    }
-    else {
-        localStorage.setItem("mode", "dark");
-        themeButton.value = "Enable Light Mode";
-        document.body.style.backgroundColor = "#202124";
-        document.getElementById("header").style.backgroundColor = "#202124";
-        document.getElementById("spn").style.color = "whitesmoke";
-        for (let i = 0; i < svg5.length; i++) {
-            svg5[i].style.fill = "rgba(255, 255, 255, 0.1)";
-        }
-        for (let i = 0; i < svg3.length; i++) {
-            svg3[i].style.fill = "#212121";
-        }
-        for (let i = 0; i < svg4.length; i++) {
-            svg4[i].style.fill = "#dfe0e4";
-        }
-    }
+    });
     systemThemeToggle = false;
 }
 

--- a/scripts/darkMode.js
+++ b/scripts/darkMode.js
@@ -1,13 +1,14 @@
+let systemThemeToggle = false;
 function toggle() {
-    if(!localStorage.getItem("mode")){
-        localStorage.setItem("mode", "dark");
-    }
+    
     let themeButton = document.getElementById("unchecked");
     let svg5 = document.getElementsByClassName('st5');
     let svg3 = document.getElementsByClassName('st3');
     let svg4 = document.getElementsByClassName('st4');
     if (themeButton.value === "Enable Light Mode"){
-        localStorage.setItem("mode", "light");
+        if(!systemThemeToggle){
+            localStorage.setItem("mode", "light");
+        }
         themeButton.value = "Enable Dark Mode";
         document.body.style.backgroundColor = "#f5f5f5";
         document.getElementById("header").style.backgroundColor = "#f5f5f5";
@@ -38,10 +39,18 @@ function toggle() {
             svg4[i].style.fill = "#dfe0e4";
         }
     }
+    systemThemeToggle = false;
 }
 
 function checkMode(){
     let mode = localStorage.getItem("mode");
+    // If user hasn't made a choice, use default theme
+    if(mode === null){
+        // Check if system dark mode is on, otherwise use dark
+        mode = window.matchMedia('(prefers-color-scheme: light)').matches ? "light" : "dark";
+        // Don't save this as user preference
+        systemThemeToggle = true;
+    }
     if(mode === "light"){
         document.getElementById("unchecked").click();
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -121,3 +121,15 @@ header {
 .uname, #spn a:link, #spn a:visited{
     color: var(--accent-green);
 }
+
+#darkthemecurtain {
+    position: absolute;
+    display: none;
+    height: 26px;
+    width: 26px;
+    border-radius: 50%;
+    background: rgb(245, 245, 245);
+    transition: transform 200ms ease-out, opacity 160ms ease-out;
+    z-index: 998;
+    opacity: 1;
+}


### PR DESCRIPTION
### Now defaults to system theme

If API is available and user hasn't made a choice yet, the dark/light theme will be set to match system theme. Will need clearing website storage to take effect for users coming from the current version, otherwise they will be served the last set theme.

### Added a curtain/ripple animation when switching the theme

I remember you asked me about that effect on my website so I thought I might throw that in. You might need to test it a bit more, because I only quickly checked if it works. And also it doesn't support browsers without `addEventListener once` [(caniuse)](https://caniuse.com/#feat=once-event-listener) but you can fix that by manually removing the event listeners once they run if you want to.